### PR TITLE
Fix vim's "iskeyword" setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In your vimrc, I recommend putting in the following lines to ensure variables co
 ```vim
 augroup custom_nginx
   autocmd!
-  autocmd FileType nginx set iskeyword+=$
+  autocmd FileType nginx setlocal iskeyword+=$
   autocmd FileType nginx let b:coc_additional_keywords = ['$']
 augroup end
 ```


### PR DESCRIPTION
## Description

If you use `autocmd FileType nginx set iskeyword+=$`, you are changing the global iskeyword setting. In the next file you open, the `$` will be added `iskeyword` as well.

1. Open "nginx.conf" (`$` will be added to `iskeyword`)
2. For example, the next time you open a `python` file, the `$` is still added to iskeyword.

![nginx-ls-readme-fix](https://user-images.githubusercontent.com/188642/115326552-6a119380-a1c8-11eb-95b2-103addf130f4.gif)

## Fix

I changed it to `setlocal`.

This will add `$` to iskeyword only if the "filetype" is `nginx`.

